### PR TITLE
Use ticket_price instead of amount_paid in registrant.html

### DIFF
--- a/www/partials/registrant.html
+++ b/www/partials/registrant.html
@@ -55,8 +55,11 @@
                     <tr ng-show="registrant.personal_data.personalHomepage">
                         <th>Personal homepage</th><td>{{registrant.personal_data.personalHomepage}}</td>
                     </tr>
+                    <tr ng-show="registrant.ticket_price">
+                        <th>Amount to pay</td><td>{{registrant.ticket_price}}</td>
+                    </tr>
                     <tr ng-show="registrant.amount_paid">
-                        <th>Amount to pay</td><td>{{registrant.amount_paid}}</td>
+                        <th>Amount paid</td><td>{{registrant.amount_paid}}</td>
                     </tr>
                     <tr ng-show="registrant.paid">
                         <th>Paid</th><td>{{registrant.paid && 'Yes' || 'No' }}</td>


### PR DESCRIPTION
The app does not display ticket price if not already paid. For this, a PR is raised with indico https://github.com/indico/indico/pull/3911 adding a new field in registrants API call.
I have added a new field in the registrant.html template "Amount Paid" which retains the original behaviour of reading info from amount_paid. "Amount to pay" now reads info from "ticket_price" field.
Both these have been retained in case indico and indico-checkin are not at latest version.