### PR TITLE
Support http connections on Android < 28

### DIFF
--- a/res/xml/network_security_config.xml
+++ b/res/xml/network_security_config.xml
@@ -1,0 +1,5 @@
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain>http://localhost</domain>
+    </domain-config>
+</network-security-config>

--- a/www/config.xml
+++ b/www/config.xml
@@ -29,8 +29,9 @@
     <preference name="SplashScreenDelay" value="4000" />
     <platform name="android">
         <edit-config xmlns:android="http://schemas.android.com/apk/res/android" file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
-            <application android:usesCleartextTraffic="true" />
+            <application android:networkSecurityConfig="@xml/network_security_config" />
         </edit-config>
+        <resource-file src="res/xml/network_security_config.xml" target="app/src/main/res/xml/network_security_config.xml" />
         <icon gap:density="ldpi" src="res/icon/android/icon-36-ldpi.png" />
         <icon gap:density="mdpi" src="res/icon/android/icon-48-mdpi.png" />
         <icon gap:density="hdpi" src="res/icon/android/icon-72-hdpi.png" />

--- a/www/config.xml
+++ b/www/config.xml
@@ -28,6 +28,9 @@
     <preference name="SplashScreenSpinnerColor" value="#03a4e4" />
     <preference name="SplashScreenDelay" value="4000" />
     <platform name="android">
+        <edit-config xmlns:android="http://schemas.android.com/apk/res/android" file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
+            <application android:usesCleartextTraffic="true" />
+        </edit-config>
         <icon gap:density="ldpi" src="res/icon/android/icon-36-ldpi.png" />
         <icon gap:density="mdpi" src="res/icon/android/icon-48-mdpi.png" />
         <icon gap:density="hdpi" src="res/icon/android/icon-72-hdpi.png" />


### PR DESCRIPTION
In Android 28+ only https is allowed unless `usesCleartextTraffic` is enabled.